### PR TITLE
Encoding of Single Quotes in Swagger Generated cURL 

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -5230,8 +5230,13 @@ Operation.prototype.asCurl = function (args1, args2) {
     results.push('-d \'' + body.replace(/\'/g, '\\u0027') + '\'');
   }
 
-  return 'curl ' + (results.join(' ')) + ' \'' + obj.url + '\'';
+   return 'curl ' + (results.join(' ')) + ' \'' + this.formatURLForCurl(obj.url) + '\'';
 };
+
+Operation.prototype.formatURLForCurl = function(url) {
+    return url.replace(/\'/g, '%27');
+};
+
 
 Operation.prototype.encodePathCollection = function (type, name, value) {
   var encoded = '';


### PR DESCRIPTION
* Replaces all single quotes in a generated cURL URL with an encoded version
* Closes #11